### PR TITLE
fix(package.json): `htm` and `preact` as dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,7 @@
     "eslint-plugin-bpmn-io": "^0.16.0",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-react-hooks": "^4.2.0",
-    "htm": "^3.1.1",
     "npm-run-all": "^4.1.5",
-    "preact": "^10.11.2",
     "diagram-js": "^9.1.0",
     "karma": "^6.4.1",
     "karma-chrome-launcher": "^3.1.1",
@@ -41,5 +39,9 @@
     "sinon": "^14.0.1",
     "sinon-chai": "^3.7.0",
     "webpack": "^5.74.0"
+  },
+  "dependencies": {
+    "htm": "^3.1.1",
+    "preact": "^10.11.2"
   }
 }


### PR DESCRIPTION
Since these are not bundled by `diagram-js-ui` and to be used in production, we should move these from devDependencies to dependencies.