### PR TITLE
Export all Preact exports

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1,2 +1,4 @@
-export * from 'htm/preact';
+export { html } from 'htm/preact';
+
+export * from 'preact';
 export * from 'preact/hooks';

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,2 +1,4 @@
-export * from 'htm/preact';
+export { html } from 'htm/preact';
+
+export * from 'preact';
 export * from 'preact/hooks';

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "files": [
     "lib"
   ],
+  "sideEffects": false,
   "scripts": {
     "all": "run-s lint test",
     "lint": "eslint .",

--- a/test/indexSpec.js
+++ b/test/indexSpec.js
@@ -1,30 +1,45 @@
-import {
-  html,
-  render,
-  h,
-  Component,
-  useState,
-  useCallback,
-  useLayoutEffect
-} from '..';
+import * as preactExports from 'preact';
+import * as preactHooksExports from 'preact/hooks';
+
+import * as htmExports from 'htm/preact';
+
+import * as duiExports from '..';
 
 
 describe('diagram-js-ui', function() {
 
-  Object.entries({
-    html,
-    render,
-    Component,
-    h,
-    useState,
-    useCallback,
-    useLayoutEffect
-  }).map(([ name, value ]) => {
+  describe('preact exports', function() {
 
-    it(`should export ${ name }`, function() {
-      expect(value, `export <${ name }>`).to.exist;
-    });
+    verifyExports(preactExports);
+
+  });
+
+
+  describe('preact/hooks exports', function() {
+
+    verifyExports(preactHooksExports);
+
+  });
+
+
+  describe('htm exports', function() {
+
+    verifyExports(htmExports);
 
   });
 
 });
+
+
+// helpers //////////////
+
+function verifyExports(expectedExports) {
+
+  Object.entries(expectedExports).map(([ name, value ]) => {
+
+    it(`should export ${ name }`, function() {
+      expect(duiExports[name], `export <${ name }>`).to.equal(value);
+    });
+  });
+
+}


### PR DESCRIPTION
Allows us to use available tooling reliably. Fixes `v0.2.1`, which broke this in the first place.

Closes https://github.com/bpmn-io/diagram-js-ui/issues/12